### PR TITLE
Fix range, include plus symbol, add no wrap

### DIFF
--- a/app/src/lib/Aspect.svelte
+++ b/app/src/lib/Aspect.svelte
@@ -8,14 +8,14 @@
   export let aspect
 
   function formatText(text) {
-    const regex = /(x?){([^}]+)}(%?)/g
+    const regex = /([x+]?){([^}]+)}(%?)/g
     const matches = text.matchAll(regex)
 
     let replace = text
 
     for (const match of matches) {
       const [keyword, x, range, percent] = match
-      const stats = `<span class="text-blue-500">${x}[${range?.replace(
+      const stats = `<span class="text-blue-500 whitespace-nowrap">${x}[${range?.replace(
         '/',
         '-'
       )}]${percent}</span>`


### PR DESCRIPTION
- Include `+` sign in the highlighted range `+[10-20]%`
- Add `white-space: nowrap` to avoid breaking the range into lines


Before
![image](https://github.com/fawadasaurus/d4-aspect-tracker/assets/831065/ce513a28-619d-4496-b9e1-905df072552c)

After
![image](https://github.com/fawadasaurus/d4-aspect-tracker/assets/831065/077412a4-6f36-4a0f-97ea-4be2b885a3a7)


