### PR TITLE
Fix undefined for non-integer number bigger than 5

### DIFF
--- a/app/src/lib/AddOwned.svelte
+++ b/app/src/lib/AddOwned.svelte
@@ -58,12 +58,12 @@
 
   function roundDecimals(number) {
     if (Number.isInteger(number)) {
-      return number.toString() // Return non-decimal value without decimal places
-    } else if (number < 1) {
-      return number.toFixed(2) // Round decimal value to 4 decimal places
-    } else if (number < 5) {
-      return number.toFixed(1) // Round decimal value to 2 decimal places
+      return number.toFixed(0)
     }
+    if (number < 1) {
+      return number.toFixed(2)
+    }
+    return number.toFixed(1)
   }
 
   function addOwnedAspect() {
@@ -111,7 +111,7 @@
       bind:value={selectedSlot}
     />
     <Button on:click={addOwnedAspect} class="text-xs md:text-base py-1 px-2"
-      >Add</Button
-    >
+      >Add
+    </Button>
   </div>
 </Card>


### PR DESCRIPTION
- Fix `undefined` if the input is not an integer and more than 5 
- Remove comments because they don't match the code
- Consistently return number type instead of mixed string/number

![image](https://github.com/fawadasaurus/d4-aspect-tracker/assets/831065/ca8eddfc-7a3c-4828-8c68-3e4a13c2bec8)
