### PR TITLE
Clean up UI, remove paddings, align form controls

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -207,38 +207,30 @@
 <div class="max-w-md mx-auto p-4">
   <div class="mb-8">
     <h1 class="text-2xl text-red-600 font-medium mb-4">D4 Aspect Tracker</h1>
-    <div class="mr-4">
-      <Input
-        bind:value={searchTerm}
-        placeholder="Search by name or description"
-        class="mt-2"
-      />
-    </div>
-    <div class="mr-4">
-      <Select
-        placeholder="Select a class"
-        class="mt-2"
-        items={classes}
-        bind:value={selectedClass}
-      />
-    </div>
-    <div class="mr-4">
-      <Select
-        placeholder="Select item slot"
-        class="mt-2"
-        items={slots}
-        bind:value={selectedSlot}
-      />
-    </div>
-    <div class="mr-4">
-      <Select
-        placeholder="Both In Codex and Not in Codex"
-        class="mt-2"
-        items={codex}
-        bind:value={selectedCodex}
-      />
-    </div>
-    <div class="mr-4 mt-2">
+    <Input
+      bind:value={searchTerm}
+      placeholder="Search by name or description"
+      class="mt-2"
+    />
+    <Select
+      placeholder="Select a class"
+      class="mt-2"
+      items={classes}
+      bind:value={selectedClass}
+    />
+    <Select
+      placeholder="Select item slot"
+      class="mt-2"
+      items={slots}
+      bind:value={selectedSlot}
+    />
+    <Select
+      placeholder="Both In Codex and Not in Codex"
+      class="mt-2"
+      items={codex}
+      bind:value={selectedCodex}
+    />
+    <div class="mt-2">
       <Checkbox class="text-base" bind:checked={limitToOwned}>
         Limit to owned</Checkbox
       >

--- a/app/src/lib/AddOwned.svelte
+++ b/app/src/lib/AddOwned.svelte
@@ -94,6 +94,7 @@
     localStorage.setItem(aspectName, JSON.stringify(ownedAspects))
     dispatch('aspectUpdated')
     aspectValue = ''
+    selectedSlot = ''
   }
 </script>
 

--- a/app/src/lib/AddOwned.svelte
+++ b/app/src/lib/AddOwned.svelte
@@ -98,21 +98,19 @@
   }
 </script>
 
-<div>
-  <div class="flex">
-    <Input
-      type="number"
-      min="0"
-      inputmode="numeric"
-      bind:value={aspectValue}
-      placeholder="Enter value"
-      class="mr-2"
-    />
-    <Select
-      class="mr-2"
-      items={aspectSlots[aspectCategory] || []}
-      bind:value={selectedSlot}
-    />
-    <Button on:click={addOwnedAspect} color="yellow" outline>Add</Button>
-  </div>
+<div class="flex">
+  <Input
+    type="number"
+    min="0"
+    inputmode="numeric"
+    bind:value={aspectValue}
+    placeholder="Enter value"
+    class="mr-2"
+  />
+  <Select
+    class="mr-2"
+    items={aspectSlots[aspectCategory] || []}
+    bind:value={selectedSlot}
+  />
+  <Button on:click={addOwnedAspect} color="yellow" outline>Add</Button>
 </div>

--- a/app/src/lib/AddOwned.svelte
+++ b/app/src/lib/AddOwned.svelte
@@ -67,6 +67,8 @@
   }
 
   function addOwnedAspect() {
+    if (Number(aspectValue) === 0) return
+
     const divider =
       selectedSlot === 'Amulet' ? 1.5 : selectedSlot === '2H-Weapon' ? 2 : 1
     const actualAspectValue = roundDecimals(
@@ -74,10 +76,12 @@
     )
     let shownValue = ''
     if (actualAspectValue != aspectValue) {
-      shownValue = ' (' + aspectValue + ')'
+      shownValue = '(' + aspectValue + ')'
     }
     const ownedAspect: OwnedAspect = {
-      note: actualAspectValue + ', ' + selectedSlot + shownValue,
+      note: `${actualAspectValue}${
+        selectedSlot ? ', ' : ''
+      }${selectedSlot} ${shownValue}`,
       time: new Date().toLocaleString(),
     }
 
@@ -93,25 +97,21 @@
   }
 </script>
 
-<Card class="p-2 md:p-4">
-  <h3 class="text-sm md:text-base">Add Owned Aspect</h3>
-  <div class="flex items-center">
+<div>
+  <div class="flex">
     <Input
       type="number"
       min="0"
       inputmode="numeric"
       bind:value={aspectValue}
       placeholder="Enter value"
-      class="text-xs md:text-base mr-2"
+      class="mr-2"
     />
     <Select
-      placeholder="Select slot"
-      class="mt-2"
+      class="mr-2"
       items={aspectSlots[aspectCategory] || []}
       bind:value={selectedSlot}
     />
-    <Button on:click={addOwnedAspect} class="text-xs md:text-base py-1 px-2"
-      >Add</Button
-    >
+    <Button on:click={addOwnedAspect} color="yellow" outline>Add</Button>
   </div>
-</Card>
+</div>

--- a/app/src/lib/Aspect.svelte
+++ b/app/src/lib/Aspect.svelte
@@ -33,26 +33,24 @@
   $: ownedAspects = JSON.parse(localStorage.getItem(aspect.name)) || []
 </script>
 
-<div class="max-w-sm mb-10 border rounded-lg">
-  <div style="padding:10px">
-    <h3 class="text-lg font-medium mb-2 text-amber-600">
-      {aspect.name}, {aspect.category}
-      {aspect.in_codex ? '(Codex)' : ''}
-    </h3>
-    <p class="text-base mb-4">{@html formatText(aspect.desc)}</p>
+<div class="mb-10">
+  <h3 class="text-lg font-medium mb-2 text-amber-600">
+    {aspect.name}, {aspect.category}
+    {aspect.in_codex ? '(Codex)' : ''}
+  </h3>
+  <p class="text-base mb-4">{@html formatText(aspect.desc)}</p>
 
-    {#if ownedAspects.length > 0}
-      <ListOwned
-        aspectName={aspect.name}
-        {ownedAspects}
-        on:aspectUpdated={handleAspectUpdated}
-      />
-    {/if}
-    <AddOwned
+  {#if ownedAspects.length > 0}
+    <ListOwned
       aspectName={aspect.name}
-      aspectCategory={aspect.category}
       {ownedAspects}
       on:aspectUpdated={handleAspectUpdated}
     />
-  </div>
+  {/if}
+  <AddOwned
+    aspectName={aspect.name}
+    aspectCategory={aspect.category}
+    {ownedAspects}
+    on:aspectUpdated={handleAspectUpdated}
+  />
 </div>


### PR DESCRIPTION
- Clean up UI a little bit: remove unnecessary paddings, margins, and borders
- Don't add aspects if no value is entered
- Don't display comma if no slot is selected
- Reset the selected slot after the aspect is added

![image](https://github.com/fawadasaurus/d4-aspect-tracker/assets/831065/193d3d3b-b05f-42f8-a8cc-500236e672eb)
