### PR TITLE
Handle Aspect load json parse error

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -135,7 +135,9 @@
         }
         const values = localStorage.getItem(key)
         if (values) {
-          loadedOwnedAspects[key] = JSON.parse(values)
+          try {
+            loadedOwnedAspects[key] = JSON.parse(values)
+          } catch {}
         }
       }
     }


### PR DESCRIPTION
In some cases, a browser extension may use the local storage without a JSON payload. The app throws an error when it tries to do a JSON parse, preventing any further JS interactions. Add a `try-catch` to handle non-json local storage values.

<img width="1530" alt="Screenshot 2023-07-14 at 8 25 05 AM" src="https://github.com/fawadasaurus/d4-aspect-tracker/assets/628049/05f163a1-8925-4d5d-8c90-f3556edf1359">
